### PR TITLE
cleanup header

### DIFF
--- a/bbparse.h
+++ b/bbparse.h
@@ -78,7 +78,6 @@ struct tcp_log_buffer_v8
 	uint8_t		_pad[3];	/* Padding */
 	/* Per-stack info */
 	union tcp_log_stackspecific tlb_stackinfo;
-#define	tlb_rack	tlb_stackinfo.u_rack
 
 	/* The packet */
 	uint32_t	tlb_len;	/* The packet's data length */


### PR DESCRIPTION
"tlb_rack" and "tlb_stackinfo.u_rack" are not actually used anywhere in the kernel or ports, so remove the unnecessary define. It does not look like these were actually ever referenced (e.g. read_bbrlog).

More importantly, `u_rack` is being removed from `tlb_stackinfo` in the kernel header (via D49669)